### PR TITLE
Fixing SYSEX MIDI channel handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,11 @@ jobs:
       run: |
            set -ex
            git submodule update --init --recursive
-    - name: Use Circle develop branch for WM8960 support until it is merged upstream
+    - name: Use Circle develop branch for WM8960 and i2c display support until it is merged upstream
       run: |
            set -ex
            cd circle-stdlib/libs/circle
-           git checkout ae22928 # develop
+           git checkout c9a4815 # develop
            cd -
     - name: Install toolchains
       run: |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Video about this project by [Floyd Steinberg](https://www.youtube.com/watch?v=Z3
 
 * Raspberry Pi 1, 2, 3, 4, or 400 (Zero and Zero 2 can be used but need HDMI or a supported i2s DAC for audio out). On Raspberry Pi 1 and on Raspberry Pi Zero there will be severely limited functionality (only one tone generator instead of 8)
 * A [PCM5102A or PCM5122 based DAC](https://github.com/probonopd/MiniDexed/wiki/Hardware#i2c-dac), HDMI display or [audio extractor](https://github.com/probonopd/MiniDexed/wiki/Hardware#hdmi-to-audio) for good sound quality. If you don't have this, you can use the headphone jack on the Raspberry Pi but on anything but the Raspberry 4 the sound quality will be seriously limited
-* Optionally (but highly recommended), an [LCDC1602 Display](https://www.berrybase.de/en/sensors-modules/displays/alphanumeric-displays/alphanumerisches-lcd-16x2-gr-252-n/gelb) (not i2c) and a [KY-040 rotary encoder](https://www.berrybase.de/en/components/passive-components/potentiometer/rotary-encoder/drehregler/rotary-encoder-mit-breakoutboard-ohne-gewinde-und-mutter)
+* Optionally (but highly recommended), an [LCDC1602 Display](https://www.berrybase.de/en/sensors-modules/displays/alphanumeric-displays/alphanumerisches-lcd-16x2-gr-252-n/gelb) (with or without i2c "backpack" board) and a [KY-040 rotary encoder](https://www.berrybase.de/en/components/passive-components/potentiometer/rotary-encoder/drehregler/rotary-encoder-mit-breakoutboard-ohne-gewinde-und-mutter)
 
 ## Usage
 
@@ -43,6 +43,7 @@ Video about this project by [Floyd Steinberg](https://www.youtube.com/watch?v=Z3
 * Alternatively, attach a  PCM5102A or PCM5122 based DAC and select i2c sound output using `SoundDevice=i2s` in `minidexed.ini` (best audio quality)
 * Alternatively, attach a HDMI display with sound and select HDMI sound output using `SoundDevice=hdmi` in `minidexed.ini` (this may introduce slight latency)
 * Attach a MIDI keyboard via USB (alternatively you can build a circuit that allows you to attach a "traditional" MIDI keyboard using a DIN connector, or use a DIN-MIDI-to-USB adapter)
+* If you are using a LCDC1602 with an i2c "backpack" board, then you need to set `LCDI2CAddress=0x27` (or another address your i2c "backpack" board is set to) in `minidexed.ini`
 * Boot
 * Start playing
 * If the system seems to become unresponsive after a few seconds, remove `usbspeed=full` from `cmdline.txt` and repeat ([details](https://github.com/probonopd/MiniDexed/issues/39))

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -79,6 +79,7 @@ void CConfig::Load (void)
 	m_nLCDPinData5 = m_Properties.GetNumber ("LCDPinData5", 23);
 	m_nLCDPinData6 = m_Properties.GetNumber ("LCDPinData6", 24);
 	m_nLCDPinData7 = m_Properties.GetNumber ("LCDPinData7", 25);
+	m_nLCDI2CAddress = m_Properties.GetNumber ("LCDI2CAddress", 0);
 
 	m_bEncoderEnabled = m_Properties.GetNumber ("EncoderEnabled", 0) != 0;
 	m_nEncoderPinClock = m_Properties.GetNumber ("EncoderPinClock", 10);
@@ -172,6 +173,11 @@ unsigned CConfig::GetLCDPinData6 (void) const
 unsigned CConfig::GetLCDPinData7 (void) const
 {
 	return m_nLCDPinData7;
+}
+
+unsigned CConfig::GetLCDI2CAddress (void) const
+{
+	return m_nLCDI2CAddress;
 }
 
 bool CConfig::GetEncoderEnabled (void) const

--- a/src/config.h
+++ b/src/config.h
@@ -86,6 +86,7 @@ public:
 	unsigned GetLCDPinData5 (void) const;
 	unsigned GetLCDPinData6 (void) const;
 	unsigned GetLCDPinData7 (void) const;
+	unsigned GetLCDI2CAddress (void) const;
 
 	// KY-040 Rotary Encoder
 	// GPIO pin numbers are chip numbers, not header positions
@@ -120,6 +121,7 @@ private:
 	unsigned m_nLCDPinData5;
 	unsigned m_nLCDPinData6;
 	unsigned m_nLCDPinData7;
+	unsigned m_nLCDI2CAddress;
 
 	bool m_bEncoderEnabled;
 	unsigned m_nEncoderPinClock;

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -256,7 +256,6 @@ void CMiniDexed::Process (bool bPlugAndPlayUpdated)
 	if (m_bUseSerial)
 	{
 		m_SerialMIDI.Process ();
-		m_SerialMIDI.Process ();
 	}
 
 	m_UI.Process ();

--- a/src/minidexed.cpp
+++ b/src/minidexed.cpp
@@ -37,7 +37,7 @@ CMiniDexed::CMiniDexed (CConfig *pConfig, CInterruptSystem *pInterrupt,
 	CMultiCoreSupport (CMemorySystem::Get ()),
 #endif
 	m_pConfig (pConfig),
-	m_UI (this, pGPIOManager, pConfig),
+	m_UI (this, pGPIOManager, pI2CMaster, pConfig),
 	m_PerformanceConfig (pFileSystem),
 	m_PCKeyboard (this, pConfig),
 	m_SerialMIDI (this, pInterrupt, pConfig),

--- a/src/minidexed.h
+++ b/src/minidexed.h
@@ -130,6 +130,11 @@ public:
 		TGParameterResonance,
 		TGParameterMIDIChannel,
 		TGParameterReverbSend,
+		TGParameterPitchBendRange, 
+		TGParameterPitchBendStep,
+		TGParameterPortamentoMode,
+		TGParameterPortamentoGlissando,
+		TGParameterPortamentoTime,
 		TGParameterUnknown
 	};
 
@@ -177,6 +182,11 @@ private:
 	int m_nCutoff[CConfig::ToneGenerators];
 	int m_nResonance[CConfig::ToneGenerators];
 	unsigned m_nMIDIChannel[CConfig::ToneGenerators];
+	unsigned m_nPitchBendRange[CConfig::ToneGenerators];	
+	unsigned m_nPitchBendStep[CConfig::ToneGenerators];	
+	unsigned m_nPortamentoMode[CConfig::ToneGenerators];	
+	unsigned m_nPortamentoGlissando[CConfig::ToneGenerators];	
+	unsigned m_nPortamentoTime[CConfig::ToneGenerators];	
 
 	unsigned m_nNoteLimitLow[CConfig::ToneGenerators];
 	unsigned m_nNoteLimitHigh[CConfig::ToneGenerators];

--- a/src/minidexed.ini
+++ b/src/minidexed.ini
@@ -25,6 +25,7 @@ LCDPinData4=22
 LCDPinData5=23
 LCDPinData6=24
 LCDPinData7=25
+LCDI2CAddress=0x00
 
 # KY-040 Rotary Encoder
 EncoderEnabled=1

--- a/src/performance.ini
+++ b/src/performance.ini
@@ -15,6 +15,11 @@
 #NoteLimitHigh#=127	# 0 .. 127, C-2 .. G8
 #NoteShift#=0		# -24 .. 24
 #ReverbSend#=0		# 0 .. 99
+#PitchBendRange#=2 # 0 .. 12
+#PitchBendStep#=0 # 0 .. 12
+#PortamentoMode#=0 # 0 .. 1
+#PortamentoGlissando#=0 # 0 .. 1
+#PortamentoTime#=0 # 0 .. 99
 
 # TG1
 BankNumber1=0
@@ -29,6 +34,11 @@ NoteLimitLow1=0
 NoteLimitHigh1=127
 NoteShift1=0
 ReverbSend1=99
+PitchBendRange1=2
+PitchBendStep1=0
+PortamentoMode1=0
+PortamentoGlissando1=0
+PortamentoTime1=0
 
 # TG2
 BankNumber2=0
@@ -43,6 +53,11 @@ NoteLimitLow2=0
 NoteLimitHigh2=127
 NoteShift2=0
 ReverbSend2=70
+PitchBendRange2=2
+PitchBendStep2=0
+PortamentoMode2=0
+PortamentoGlissando2=0
+PortamentoTime2=0
 
 # TG3
 BankNumber3=0
@@ -57,6 +72,11 @@ NoteLimitLow3=0
 NoteLimitHigh3=127
 NoteShift3=0
 ReverbSend3=0
+PitchBendRange3=2
+PitchBendStep3=0
+PortamentoMode3=0
+PortamentoGlissando3=0
+PortamentoTime3=0
 
 # TG4
 BankNumber4=0
@@ -71,6 +91,11 @@ NoteLimitLow4=0
 NoteLimitHigh4=127
 NoteShift4=0
 ReverbSend4=0
+PitchBendRange4=2
+PitchBendStep4=0
+PortamentoMode4=0
+PortamentoGlissando4=0
+PortamentoTime4=0
 
 # TG5
 BankNumber5=0
@@ -85,6 +110,11 @@ NoteLimitLow5=0
 NoteLimitHigh5=127
 NoteShift5=0
 ReverbSend5=0
+PitchBendRange5=2
+PitchBendStep5=0
+PortamentoMode5=0
+PortamentoGlissando5=0
+PortamentoTime5=0
 
 # TG6
 BankNumber6=0
@@ -99,6 +129,11 @@ NoteLimitLow6=0
 NoteLimitHigh6=127
 NoteShift6=0
 ReverbSend6=0
+PitchBendRange6=2
+PitchBendStep6=0
+PortamentoMode6=0
+PortamentoGlissando6=0
+PortamentoTime6=0
 
 # TG7
 BankNumber7=0
@@ -113,6 +148,11 @@ NoteLimitLow7=0
 NoteLimitHigh7=127
 NoteShift7=0
 ReverbSend7=0
+PitchBendRange7=2
+PitchBendStep7=0
+PortamentoMode7=0
+PortamentoGlissando7=0
+PortamentoTime7=0
 
 # TG8
 BankNumber8=0
@@ -127,6 +167,11 @@ NoteLimitLow8=0
 NoteLimitHigh8=127
 NoteShift8=0
 ReverbSend8=0
+PitchBendRange8=2
+PitchBendStep8=0
+PortamentoMode8=0
+PortamentoGlissando8=0
+PortamentoTime8=0
 
 # Effects
 #CompressorEnable=1	# 0: off, 1: on

--- a/src/performanceconfig.cpp
+++ b/src/performanceconfig.cpp
@@ -98,7 +98,22 @@ bool CPerformanceConfig::Load (void)
 
 		PropertyName.Format ("ReverbSend%u", nTG+1);
 		m_nReverbSend[nTG] = m_Properties.GetNumber (PropertyName, 50);
-	}
+		
+		PropertyName.Format ("PitchBendRange%u", nTG+1);
+		m_nPitchBendRange[nTG] = m_Properties.GetNumber (PropertyName, 2);
+
+		PropertyName.Format ("PitchBendStep%u", nTG+1);
+		m_nPitchBendStep[nTG] = m_Properties.GetNumber (PropertyName, 0);
+
+		PropertyName.Format ("PortamentoMode%u", nTG+1);
+		m_nPortamentoMode[nTG] = m_Properties.GetNumber (PropertyName, 0);
+
+		PropertyName.Format ("PortamentoGlissando%u", nTG+1);
+		m_nPortamentoGlissando[nTG] = m_Properties.GetNumber (PropertyName, 0);
+
+		PropertyName.Format ("PortamentoTime%u", nTG+1);
+		m_nPortamentoTime[nTG] = m_Properties.GetNumber (PropertyName, 0);
+		}
 
 	m_bCompressorEnable = m_Properties.GetNumber ("CompressorEnable", 1) != 0;
 
@@ -169,7 +184,22 @@ bool CPerformanceConfig::Save (void)
 
 		PropertyName.Format ("ReverbSend%u", nTG+1);
 		m_Properties.SetNumber (PropertyName, m_nReverbSend[nTG]);
-	}
+		
+		PropertyName.Format ("PitchBendRange%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nPitchBendRange[nTG]);
+
+		PropertyName.Format ("PitchBendStep%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nPitchBendStep[nTG]);
+
+		PropertyName.Format ("PortamentoMode%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nPortamentoMode[nTG]);
+
+		PropertyName.Format ("PortamentoGlissando%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nPortamentoGlissando[nTG]);
+
+		PropertyName.Format ("PortamentoTime%u", nTG+1);
+		m_Properties.SetNumber (PropertyName, m_nPortamentoTime[nTG]);
+		}
 
 	m_Properties.SetNumber ("CompressorEnable", m_bCompressorEnable ? 1 : 0);
 
@@ -406,4 +436,68 @@ void CPerformanceConfig::SetReverbDiffusion (unsigned nValue)
 void CPerformanceConfig::SetReverbLevel (unsigned nValue)
 {
 	m_nReverbLevel = nValue;
+}
+// Pitch bender and portamento:
+void CPerformanceConfig::SetPitchBendRange (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nPitchBendRange[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetPitchBendRange (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nPitchBendRange[nTG];
+}
+
+
+void CPerformanceConfig::SetPitchBendStep (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nPitchBendStep[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetPitchBendStep (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nPitchBendStep[nTG];
+}
+
+
+void CPerformanceConfig::SetPortamentoMode (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nPortamentoMode[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetPortamentoMode (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nPortamentoMode[nTG];
+}
+
+
+void CPerformanceConfig::SetPortamentoGlissando (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nPortamentoGlissando[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetPortamentoGlissando (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nPortamentoGlissando[nTG];
+}
+
+
+void CPerformanceConfig::SetPortamentoTime (unsigned nValue, unsigned nTG)
+{
+	assert (nTG < CConfig::ToneGenerators);
+	m_nPortamentoTime[nTG] = nValue;
+}
+
+unsigned CPerformanceConfig::GetPortamentoTime (unsigned nTG) const
+{
+	assert (nTG < CConfig::ToneGenerators);
+	return m_nPortamentoTime[nTG];
 }

--- a/src/performanceconfig.h
+++ b/src/performanceconfig.h
@@ -50,7 +50,12 @@ public:
 	unsigned GetNoteLimitHigh (unsigned nTG) const;		// 0 .. 127
 	int GetNoteShift (unsigned nTG) const;			// -24 .. 24
 	unsigned GetReverbSend (unsigned nTG) const;		// 0 .. 127
-
+	unsigned GetPitchBendRange (unsigned nTG) const;		// 0 .. 12
+	unsigned GetPitchBendStep (unsigned nTG) const;		// 0 .. 12
+	unsigned GetPortamentoMode (unsigned nTG) const;		// 0 .. 1
+	unsigned GetPortamentoGlissando (unsigned nTG) const;		// 0 .. 1
+	unsigned GetPortamentoTime (unsigned nTG) const;		// 0 .. 99
+	
 	void SetBankNumber (unsigned nValue, unsigned nTG);
 	void SetVoiceNumber (unsigned nValue, unsigned nTG);
 	void SetMIDIChannel (unsigned nValue, unsigned nTG);
@@ -63,6 +68,11 @@ public:
 	void SetNoteLimitHigh (unsigned nValue, unsigned nTG);
 	void SetNoteShift (int nValue, unsigned nTG);
 	void SetReverbSend (unsigned nValue, unsigned nTG);
+	void SetPitchBendRange (unsigned nValue, unsigned nTG);
+	void SetPitchBendStep (unsigned nValue, unsigned nTG);
+	void SetPortamentoMode (unsigned nValue, unsigned nTG);
+	void SetPortamentoGlissando (unsigned nValue, unsigned nTG);
+	void SetPortamentoTime (unsigned nValue, unsigned nTG);
 
 	// Effects
 	bool GetCompressorEnable (void) const;
@@ -98,6 +108,11 @@ private:
 	unsigned m_nNoteLimitHigh[CConfig::ToneGenerators];
 	int m_nNoteShift[CConfig::ToneGenerators];
 	int m_nReverbSend[CConfig::ToneGenerators];
+	unsigned m_nPitchBendRange[CConfig::ToneGenerators];
+	unsigned m_nPitchBendStep[CConfig::ToneGenerators];
+	unsigned m_nPortamentoMode[CConfig::ToneGenerators];
+	unsigned m_nPortamentoGlissando[CConfig::ToneGenerators];
+	unsigned m_nPortamentoTime[CConfig::ToneGenerators];
 
 	bool m_bCompressorEnable;
 	bool m_bReverbEnable;

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -144,6 +144,11 @@ void CSerialMIDIDevice::Process (void)
 					m_nSerialState = 1;
 					goto DATABytes;
 				}
+				else 
+				{
+					m_nSerialState = 0;
+					goto MIDIRestart; 
+				}
 				break;
 			default:
 				assert (0);

--- a/src/serialmididevice.cpp
+++ b/src/serialmididevice.cpp
@@ -157,7 +157,6 @@ void CSerialMIDIDevice::Process (void)
 		}
 	}
 }
-
 void CSerialMIDIDevice::Send (const u8 *pMessage, size_t nLength, unsigned nCable)
 {
 	m_SendBuffer.Write (pMessage, nLength);

--- a/src/uimenu.h
+++ b/src/uimenu.h
@@ -83,6 +83,7 @@ private:
 	static void EditVoiceParameter (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void EditOPParameter (CUIMenu *pUIMenu, TMenuEvent Event);
 	static void SavePerformance (CUIMenu *pUIMenu, TMenuEvent Event);
+	static void EditTGParameter2 (CUIMenu *pUIMenu, TMenuEvent Event);
 
 	static std::string GetGlobalValueString (unsigned nParameter, int nValue);
 	static std::string GetTGValueString (unsigned nTGParameter, int nValue);
@@ -101,6 +102,8 @@ private:
 	static std::string ToKeyboardCurve (int nValue);
 	static std::string ToOscillatorMode (int nValue);
 	static std::string ToOscillatorDetune (int nValue);
+	static std::string ToPortaMode (int nValue);  
+	static std::string ToPortaGlissando (int nValue);   
 
 	void TGShortcutHandler (TMenuEvent Event);
 	void OPShortcutHandler (TMenuEvent Event);
@@ -132,7 +135,9 @@ private:
 	static const TMenuItem s_EditVoiceMenu[];
 	static const TMenuItem s_OperatorMenu[];
 	static const TMenuItem s_SaveMenu[];
-
+	static const TMenuItem s_EditPitchBendMenu[];
+	static const TMenuItem s_EditPortamentoMenu[];
+		
 	static const TParameter s_GlobalParameter[];
 	static const TParameter s_TGParameter[];
 	static const TParameter s_VoiceParameter[];

--- a/src/userinterface.h
+++ b/src/userinterface.h
@@ -26,13 +26,14 @@
 #include <display/hd44780device.h>
 #include <circle/gpiomanager.h>
 #include <circle/writebuffer.h>
+#include <circle/i2cmaster.h>
 
 class CMiniDexed;
 
 class CUserInterface
 {
 public:
-	CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManager, CConfig *pConfig);
+	CUserInterface (CMiniDexed *pMiniDexed, CGPIOManager *pGPIOManager, CI2CMaster *pI2CMaster, CConfig *pConfig);
 	~CUserInterface (void);
 
 	bool Initialize (void);
@@ -58,6 +59,7 @@ private:
 private:
 	CMiniDexed *m_pMiniDexed;
 	CGPIOManager *m_pGPIOManager;
+	CI2CMaster *m_pI2CMaster;
 	CConfig *m_pConfig;
 
 	CHD44780Device *m_pLCD;


### PR DESCRIPTION
I hope this fixes the MIDI channel handling for SYSEX messages, so there is no need anymore for setting the channel to global.
Also fixing output of SYSEX messages when MIDI-Dump is enabled.